### PR TITLE
Add map displaying SES response boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # mapexp.github.io
+
+Demonstration of displaying a polygon layer from the Victorian SES Response Boundaries service using Leaflet and Esri Leaflet.
+
+Open `index.html` in a browser or publish this repository with GitHub Pages to view the map.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no" />
+  <title>SES Response Boundaries</title>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+  <style>
+    html, body, #map {
+      height: 100%;
+      margin: 0;
+    }
+  </style>
+</head>
+<body>
+  <div id="map"></div>
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+  <script src="https://unpkg.com/esri-leaflet@3.0.9/dist/esri-leaflet.js"></script>
+  <script>
+    var map = L.map('map').setView([-37.8, 144.9], 8);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '&copy; OpenStreetMap contributors'
+    }).addTo(map);
+    var boundaries = L.esri.featureLayer({
+      url: 'https://maps.ffm.vic.gov.au/arcgis/rest/services/boundaries/MapServer/16'
+    }).addTo(map);
+    boundaries.once('load', function() {
+      map.fitBounds(boundaries.getBounds());
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `index.html` with Leaflet and Esri Leaflet to show SES Response Boundaries from the Victorian API
- Document how to view the map in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68970e21a2ec8326b4bfe3cde7cf2e44